### PR TITLE
docs: add voice and player guides

### DIFF
--- a/content/docs/plugins/official/index.mdx
+++ b/content/docs/plugins/official/index.mdx
@@ -17,6 +17,8 @@ Each of these has its own guide.
 
 | Package | What it does |
 | --- | --- |
+| [`@slipher/voice`](/docs/plugins/official/voice) | Connect to Discord voice, maintain DAVE protection, and send or receive encoded Opus audio. |
+| [`@slipher/player`](/docs/plugins/official/player) | Resolve and transcode media, then manage playback queues on top of `@slipher/voice`. |
 | [`@slipher/cooldown`](/docs/plugins/official/cooldown) | Per-command rate limits by user, guild, channel, or globally. |
 | [`@slipher/scheduler`](/docs/plugins/official/scheduler) | Cron and interval jobs managed from the Seyfert lifecycle. |
 | [`@slipher/logger`](/docs/plugins/official/logger) | Structured, request-aware logging with pluggable backends. |

--- a/content/docs/plugins/official/meta.json
+++ b/content/docs/plugins/official/meta.json
@@ -3,6 +3,8 @@
     "icon": "Boxes",
     "pages": [
         "index",
+        "voice",
+        "player",
         "cooldown",
         "scheduler",
         "logger",

--- a/content/docs/plugins/official/player.mdx
+++ b/content/docs/plugins/official/player.mdx
@@ -47,6 +47,30 @@ export const client = new Client({ plugins });
 
 `ffmpegPath` defaults to `ffmpeg`. Omit it when that executable is already available on `PATH`. The same `PlayerManager` is exposed as `client.player` and `ctx.player`.
 
+Installing [`ffmpeg-static`](https://www.npmjs.com/package/ffmpeg-static) does not place its binary on `PATH`. Install it and pass its exported path explicitly:
+
+```bash copy title="Installing a bundled FFmpeg binary"
+pnpm add ffmpeg-static
+```
+
+```ts title="src/index.ts"
+import { player } from '@slipher/player';
+import { voice } from '@slipher/voice';
+import ffmpegPath from 'ffmpeg-static';
+import { Client, definePlugins } from 'seyfert';
+
+if (!ffmpegPath) {
+    throw new Error('ffmpeg-static does not support this platform.');
+}
+
+const plugins = definePlugins(
+    voice(),
+    player({ ffmpegPath }),
+);
+
+export const client = new Client({ plugins });
+```
+
 ## Play local media
 
 Connect through the voice manager, bind a guild player to the ready connection, and enqueue a track:
@@ -187,6 +211,8 @@ The plugin also emits typed Seyfert events:
 - `playerTrackEnd`
 - `playerTrackError`
 - `playerQueueEnd`
+
+`enqueue()` resolves when an item enters the queue; opening and playback can happen later. A background failure is logged through the Seyfert client logger and emitted as `playerTrackError`. FFmpeg failures expose the executable path, exit status, signal, and a bounded stderr tail through `PlayerError.metadata`.
 
 The public player state is `idle`, `waiting`, `loading`, `playing`, `paused`, or `destroyed`.
 

--- a/content/docs/plugins/official/player.mdx
+++ b/content/docs/plugins/official/player.mdx
@@ -141,13 +141,14 @@ Enqueue one track or an array. The return value contains the generated queue ite
 ```ts
 await guildPlayer.enqueue(firstTrack);
 const added = await guildPlayer.enqueue([secondTrack, thirdTrack]);
+await guildPlayer.enqueue(playNextTrack, { position: 0 });
 
 await guildPlayer.move(added[1].id, 0);
 await guildPlayer.remove(added[0].id);
 await guildPlayer.shuffle();
 ```
 
-`remove()` and `move()` address items that are still waiting in the queue. Use `skip()` to end the current item.
+`remove()` and `move()` address items that are still waiting in the queue. The optional enqueue `position` is a zero-based index in that pending queue, so position `0` inserts a track next as one atomic operation.
 
 Control the current item through the player:
 
@@ -156,9 +157,11 @@ await guildPlayer.pause();
 await guildPlayer.resume();
 await guildPlayer.seek(30_000);
 await guildPlayer.setRepeat('queue');
-await guildPlayer.skip();
+await guildPlayer.skip(2);
 await guildPlayer.stop();
 ```
+
+A skip count includes the current item. Pending items bypassed by a multi-skip do not enter history because they never became current.
 
 Finite media pauses at its current packet boundary. A live stream closes when paused and reopens at its live edge when resumed. Seeking is available only for a finite track whose timeline is marked as seekable; it reopens the source at the requested offset through FFmpeg.
 
@@ -167,6 +170,8 @@ If the bot is muted, Stage-suppressed, moving, recovering, or disconnected, the 
 ## History and events
 
 `guildPlayer.history` is an immutable, oldest-to-newest list of completed `{ item, reason }` snapshots. Reasons include `finished`, `skipped`, `stopped`, `load-failed`, `connection-unavailable`, and `destroyed`.
+
+`guildPlayer.previous` returns the most recent history entry. For finite media, `guildPlayer.positionMs` combines the latest seek offset with the duration of Opus audio sent to Discord. It is `null` for live media or when no item is current.
 
 The default history limit is 100. Configure another bound on the plugin, disable history with `historyLimit: 0`, or clear it at runtime:
 

--- a/content/docs/plugins/official/player.mdx
+++ b/content/docs/plugins/official/player.mdx
@@ -1,0 +1,223 @@
+---
+title: Player
+description: Resolve local and remote media, transcode it when needed, and manage playback queues on top of Slipher Voice.
+---
+
+`@slipher/player` adds media sources and one playback queue per guild on top of [`@slipher/voice`](/docs/plugins/official/voice). It opens local files, URLs, radio streams, and in-memory media; uses FFmpeg when conversion is necessary; and leaves Opus pacing, RTP, encryption, and Discord voice state to the voice connection.
+
+<Callout type="info">
+Requires Seyfert v5 and the exact `@slipher/voice` plugin instance used by the client. Node.js 22.13 or newer is the primary runtime. Bun and Deno are supported through their Node.js compatibility layers.
+</Callout>
+
+## Installation
+
+```bash copy title="Installing..."
+pnpm add @slipher/player @slipher/voice seyfert
+```
+
+[FFmpeg](https://ffmpeg.org/) must be available for MP3, WAV, AAC, FLAC, unknown containers, radio, seeking, and other media that cannot go directly to the Opus demuxers. Compatible Ogg Opus and WebM Opus sources can play without starting FFmpeg.
+
+For Deno, grant read access for local files, network access for remote media, and run access when FFmpeg is needed.
+
+## Configure the plugins
+
+Create the voice plugin once and pass that same object to `player()`. The player imports it, so Seyfert installs voice first and preserves both `client.voice` and `client.player` in the registry types:
+
+```ts title="src/index.ts"
+import { player } from '@slipher/player';
+import { voice } from '@slipher/voice';
+import { Client, definePlugins } from 'seyfert';
+
+const voicePlugin = voice();
+const plugins = definePlugins(
+    player({
+        voice: voicePlugin,
+        ffmpegPath: 'ffmpeg',
+        historyLimit: 100,
+    }),
+);
+
+declare module 'seyfert' {
+    interface SeyfertRegistry {
+        plugins: typeof plugins;
+    }
+}
+
+export const client = new Client({ plugins });
+```
+
+`ffmpegPath` defaults to `ffmpeg`. Omit it when that executable is already available on `PATH`. The same `PlayerManager` is exposed as `client.player` and `ctx.player`.
+
+## Play local media
+
+Connect through the voice manager, bind a guild player to the ready connection, and enqueue a track:
+
+```ts
+import { file } from '@slipher/player';
+
+const connection = await client.voice.connect({
+    guildId,
+    channelId,
+});
+
+const guildPlayer = client.player.create(connection);
+await guildPlayer.enqueue(file('./music/song.mp3'));
+```
+
+`create(connection)` returns the existing player when the same guild and connection are already registered. If Discord destroys the connection and the bot reconnects, pass the replacement connection to `create()`; the player keeps its waiting queue and binds it to the new voice connection. Two live connections cannot own the same guild player.
+
+### Direct Opus playback
+
+Only `.opus` is inferred as Ogg Opus. An `.ogg` or `.webm` file can contain another codec, so identify a compatible container explicitly when you want to bypass FFmpeg:
+
+```ts
+await guildPlayer.enqueue(file('./music/song.ogg', { format: 'ogg-opus' }));
+await guildPlayer.enqueue(file('./music/song.webm', { format: 'webm-opus' }));
+```
+
+An explicit format means the source is already compatible. Corrupt data or a container whose audio is not Opus fails as a media error; the player does not silently retry it through FFmpeg.
+
+## Play URLs, radio, and memory
+
+Use `url()` for finite HTTP media and `radio()` for a live stream:
+
+```ts
+import { radio, url } from '@slipher/player';
+
+await guildPlayer.enqueue(
+    url('https://cdn.example.com/song.mp3', {
+        title: 'Remote song',
+    }),
+);
+
+await guildPlayer.enqueue(
+    radio('https://radio.example.com/live', {
+        title: 'Example FM',
+    }),
+);
+```
+
+Use `bytes()` when the complete source already lives in memory:
+
+```ts
+import { bytes } from '@slipher/player';
+
+await guildPlayer.enqueue(
+    bytes(audioBytes, {
+        title: 'Generated audio',
+        format: 'ogg-opus',
+    }),
+);
+```
+
+Byte tracks are process-local. They cannot be serialized, cloned into another process, or reopened after losing their in-memory backing data.
+
+## Resolve user input
+
+The manager can turn a local path, `file:` URL, or HTTP(S) URL into a track before choosing a guild player:
+
+```ts
+const result = await client.player.resolve(input);
+
+if (result.kind === 'track') {
+    await guildPlayer.enqueue(result.track);
+}
+```
+
+Resolution returns one of `track`, `playlist`, `search`, or `empty`. The built-in file and URL providers currently resolve user input; create radio and in-memory tracks through their explicit helpers.
+
+When several providers understand the same query, choose one by name:
+
+```ts
+const result = await client.player.resolve(input, {
+    provider: 'url',
+});
+```
+
+## Queue and playback controls
+
+Enqueue one track or an array. The return value contains the generated queue item IDs used by `remove()` and `move()`:
+
+```ts
+await guildPlayer.enqueue(firstTrack);
+const added = await guildPlayer.enqueue([secondTrack, thirdTrack]);
+
+await guildPlayer.move(added[1].id, 0);
+await guildPlayer.remove(added[0].id);
+await guildPlayer.shuffle();
+```
+
+`remove()` and `move()` address items that are still waiting in the queue. Use `skip()` to end the current item.
+
+Control the current item through the player:
+
+```ts
+await guildPlayer.pause();
+await guildPlayer.resume();
+await guildPlayer.seek(30_000);
+await guildPlayer.setRepeat('queue');
+await guildPlayer.skip();
+await guildPlayer.stop();
+```
+
+Finite media pauses at its current packet boundary. A live stream closes when paused and reopens at its live edge when resumed. Seeking is available only for a finite track whose timeline is marked as seekable; it reopens the source at the requested offset through FFmpeg.
+
+If the bot is muted, Stage-suppressed, moving, recovering, or disconnected, the current item ends with `connection-unavailable`. Remaining queue items wait until voice becomes playable again.
+
+## History and events
+
+`guildPlayer.history` is an immutable, oldest-to-newest list of completed `{ item, reason }` snapshots. Reasons include `finished`, `skipped`, `stopped`, `load-failed`, `connection-unavailable`, and `destroyed`.
+
+The default history limit is 100. Configure another bound on the plugin, disable history with `historyLimit: 0`, or clear it at runtime:
+
+```ts
+await guildPlayer.clearHistory();
+```
+
+History deliberately omits queue metadata and in-memory byte payloads so completed tracks do not retain arbitrary application state or media buffers.
+
+The plugin also emits typed Seyfert events:
+
+- `playerStateChange`
+- `playerTrackStart`
+- `playerTrackEnd`
+- `playerTrackError`
+- `playerQueueEnd`
+
+The public player state is `idle`, `waiting`, `loading`, `playing`, `paused`, or `destroyed`.
+
+## Add another media provider
+
+A provider can resolve a vendor-specific query, open its tracks as Opus packets, or do both:
+
+```ts
+import type { MediaProvider } from '@slipher/player';
+
+const catalogProvider: MediaProvider = {
+    name: 'catalog',
+    async resolve(query, { signal }) {
+        signal.throwIfAborted();
+        return searchCatalog(query, signal);
+    },
+    async open(track, { signal, startAtMs }) {
+        return openCatalogTrack(track, { signal, startAtMs });
+    },
+};
+
+const plugins = definePlugins(
+    player({
+        voice: voicePlugin,
+        providers: [catalogProvider],
+    }),
+);
+```
+
+`resolve()` returns a `MediaLoadResult` or `null` when the provider does not recognize the query. `open()` returns `{ packets, close }`, where `packets` is an async iterable of complete Opus packets and `close()` releases every file, stream, process, and decoder owned by that resource.
+
+Provider names must be unique. A custom provider cannot replace the built-in `bytes`, `file`, `radio`, or `url` providers. Provider errors propagate unchanged so implementations can preserve their own typed error contracts.
+
+## Package boundary
+
+`@slipher/player` owns source resolution, bounded media-resource cleanup, optional FFmpeg transcoding, per-guild queues, repeat, pause, resume, seek, skip, and voice-availability coordination. `@slipher/voice` continues to own Opus pacing, speaking signaling, RTP, DAVE, encryption, and the Discord voice connection.
+
+Spotify and YouTube extraction, vendor authentication, recommendations, volume filters, PCM mixing, recording, and Opus decoding are not built in. Add those policies through providers or higher-level plugins instead of coupling them to the Discord transport.

--- a/content/docs/plugins/official/player.mdx
+++ b/content/docs/plugins/official/player.mdx
@@ -6,7 +6,7 @@ description: Resolve local and remote media, transcode it when needed, and manag
 `@slipher/player` adds media sources and one playback queue per guild on top of [`@slipher/voice`](/docs/plugins/official/voice). It opens local files, URLs, radio streams, and in-memory media; uses FFmpeg when conversion is necessary; and leaves Opus pacing, RTP, encryption, and Discord voice state to the voice connection.
 
 <Callout type="info">
-Requires Seyfert v5 and the exact `@slipher/voice` plugin instance used by the client. Node.js 22.13 or newer is the primary runtime. Bun and Deno are supported through their Node.js compatibility layers.
+Requires Seyfert v5 and the `@slipher/voice` plugin. Node.js 22.13 or newer is the primary runtime. Bun and Deno are supported through their Node.js compatibility layers.
 </Callout>
 
 ## Installation
@@ -21,17 +21,16 @@ For Deno, grant read access for local files, network access for remote media, an
 
 ## Configure the plugins
 
-Create the voice plugin once and pass that same object to `player()`. The player imports it, so Seyfert installs voice first and preserves both `client.voice` and `client.player` in the registry types:
+Register Voice before Player. Player declares Voice as a required Seyfert plugin, and the registry order preserves both `client.voice` and `client.player` in the registry types while ensuring Player closes before Voice:
 
 ```ts title="src/index.ts"
 import { player } from '@slipher/player';
 import { voice } from '@slipher/voice';
 import { Client, definePlugins } from 'seyfert';
 
-const voicePlugin = voice();
 const plugins = definePlugins(
+    voice(),
     player({
-        voice: voicePlugin,
         ffmpegPath: 'ffmpeg',
         historyLimit: 100,
     }),
@@ -196,7 +195,9 @@ The public player state is `idle`, `waiting`, `loading`, `playing`, `paused`, or
 A provider can resolve a vendor-specific query, open its tracks as Opus packets, or do both:
 
 ```ts
-import type { MediaProvider } from '@slipher/player';
+import { player, type MediaProvider } from '@slipher/player';
+import { voice } from '@slipher/voice';
+import { definePlugins } from 'seyfert';
 
 const catalogProvider: MediaProvider = {
     name: 'catalog',
@@ -210,8 +211,8 @@ const catalogProvider: MediaProvider = {
 };
 
 const plugins = definePlugins(
+    voice(),
     player({
-        voice: voicePlugin,
         providers: [catalogProvider],
     }),
 );

--- a/content/docs/plugins/official/voice.mdx
+++ b/content/docs/plugins/official/voice.mdx
@@ -1,0 +1,287 @@
+---
+title: Voice
+description: Connect a Seyfert bot to Discord voice and send or receive encoded Opus audio with DAVE protection.
+---
+
+`@slipher/voice` connects a Seyfert bot to Discord voice channels and sends or receives encoded Opus audio. It handles the Voice Gateway, UDP transport, reconnection, and Discord's DAVE end-to-end encryption without additional setup.
+
+<Callout type="info">
+Requires Seyfert v5. The package supports Node.js 22.13 or newer, Bun, and Deno.
+</Callout>
+
+## Installation
+
+```bash copy title="Installing..."
+pnpm add @slipher/voice seyfert
+```
+
+## Configure the plugin
+
+Create the voice plugin once, include it in the client's plugin tuple, and register that tuple with `SeyfertRegistry` so `client.voice` and `ctx.voice` are typed throughout the application:
+
+```ts title="src/index.ts"
+import { voice } from '@slipher/voice';
+import { Client, definePlugins } from 'seyfert';
+
+const plugins = definePlugins(voice());
+
+declare module 'seyfert' {
+    interface SeyfertRegistry {
+        plugins: typeof plugins;
+    }
+}
+
+export const client = new Client({ plugins });
+```
+
+The plugin adds the `GuildVoiceStates` intent and listens for the Discord events required to coordinate the voice connection. You do not need to add that intent separately.
+
+## Connect to a channel
+
+Call `connect()` after the client is ready. The promise resolves when the Discord voice transport and its required encryption are ready:
+
+```ts
+const connection = await client.voice.connect({
+    guildId,
+    channelId,
+});
+```
+
+By default the bot joins self-deafened and unmuted. Pass `selfDeaf` or `selfMute` when you need a different initial state:
+
+```ts
+const connection = await client.voice.connect({
+    guildId,
+    channelId,
+    selfDeaf: false,
+    selfMute: false,
+});
+```
+
+`client.voice.connections` is a live read-only map keyed by guild ID. Calling `connect()` again for the same guild returns the existing connection when the target is unchanged.
+
+## Play an Opus file
+
+`play()` accepts complete Opus packets rather than compressed file bytes. Use the built-in demuxer to read packet boundaries from an Ogg Opus or WebM Opus stream:
+
+```ts
+import { createReadStream } from 'node:fs';
+import { demuxOggOpus } from '@slipher/voice';
+
+const playback = connection.play(
+    demuxOggOpus(createReadStream('./audio.opus')),
+);
+
+await playback.done;
+```
+
+Use `demuxWebmOpus()` for a WebM file whose audio track is Opus:
+
+```ts
+import { createReadStream } from 'node:fs';
+import { demuxWebmOpus } from '@slipher/voice';
+
+const playback = connection.play(
+    demuxWebmOpus(createReadStream('./video.webm')),
+);
+
+await playback.done;
+```
+
+The demuxers also accept a `Uint8Array` when the complete file is already in memory. They do not open paths or run FFmpeg themselves.
+
+<Callout type="warn">
+MP3, WAV, AAC, FLAC, PCM, and non-Opus WebM files must be converted to Opus before playback. The package does not transcode or encode audio.
+</Callout>
+
+<Callout type="tip">
+Use [`@slipher/player`](/docs/plugins/official/player) when you want local files, URLs, radio streams, FFmpeg transcoding, and per-guild playback queues instead of managing encoded Opus packets directly.
+</Callout>
+
+Each connection plays one source at a time. Keep the returned handle when you need to stop early:
+
+```ts
+const playback = connection.play(opusPackets);
+
+// Later, when you want to end the playback:
+await playback.stop();
+```
+
+`playback.done` resolves after the source finishes or `stop()` completes Discord's clean silence termination. It rejects when the source or voice transport fails.
+
+## Receive participant audio
+
+Discord does not send participant audio to a self-deafened bot. Connect with `selfDeaf: false`, then call `receive()` with the participant's user ID:
+
+```ts
+const connection = await client.voice.connect({
+    guildId,
+    channelId,
+    selfDeaf: false,
+});
+
+const stream = connection.receive(userId);
+
+try {
+    for await (const packet of stream) {
+        await consumeOpus(packet.opus);
+    }
+} finally {
+    stream.close();
+}
+```
+
+Each value is one authenticated Opus packet. It also includes `sequence`, `timestamp`, `ssrc`, and `userId` for downstream loss detection and routing. The stream retains at most 32 unread packets and drops the oldest packet if the consumer falls behind live audio. You can choose another bound:
+
+```ts
+const stream = connection.receive(userId, {
+    maxBufferedPackets: 64,
+});
+```
+
+### Record a participant to WAV on Node.js
+
+The receive stream contains encoded Opus, so a WAV recorder must first decode each packet to PCM. This example uses [`@discordjs/opus`](https://github.com/discordjs/opus) and writes a standard 48 kHz, stereo, signed 16-bit PCM WAV with Node.js APIs:
+
+<Callout type="info">
+This particular recorder targets Node.js. The `receive()` stream itself remains available on every runtime supported by `@slipher/voice`; use a decoder and storage sink intended for your runtime on Bun or Deno.
+</Callout>
+
+<Callout type="tip">
+`@discordjs/opus` appears here only as a consumer dependency. It is a focused Node.js binding to libopus and provides the packet-to-PCM step this WAV example needs, so the guide does not reimplement an audio codec.
+
+There is currently no plan for Seyfert or `@slipher/voice` to bundle or maintain a built-in Opus encoder or decoder. Keeping encoded Opus as the public media boundary avoids platform-specific binaries and build tooling in the core, and preserves the same voice contract across Node.js, Bun, and Deno. PCM conversion, transcoding, recording, jitter buffering, volume, and mixing remain application or plugin policy, so consumers can choose the codec and media stack appropriate for their runtime.
+</Callout>
+
+```bash copy title="Installing the Opus decoder..."
+pnpm add @discordjs/opus
+```
+
+```ts title="src/record-participant.ts"
+import opus from '@discordjs/opus';
+import type { VoiceConnection } from '@slipher/voice';
+import { open, type FileHandle } from 'node:fs/promises';
+
+const { OpusEncoder } = opus;
+const sampleRate = 48_000;
+const channels = 2;
+const bitsPerSample = 16;
+
+function createWavHeader(pcmByteLength: number): Buffer {
+    const header = Buffer.alloc(44);
+    const bytesPerSample = bitsPerSample / 8;
+    const blockAlign = channels * bytesPerSample;
+
+    header.write('RIFF', 0);
+    header.writeUInt32LE(36 + pcmByteLength, 4);
+    header.write('WAVE', 8);
+    header.write('fmt ', 12);
+    header.writeUInt32LE(16, 16);
+    header.writeUInt16LE(1, 20);
+    header.writeUInt16LE(channels, 22);
+    header.writeUInt32LE(sampleRate, 24);
+    header.writeUInt32LE(sampleRate * blockAlign, 28);
+    header.writeUInt16LE(blockAlign, 32);
+    header.writeUInt16LE(bitsPerSample, 34);
+    header.write('data', 36);
+    header.writeUInt32LE(pcmByteLength, 40);
+
+    return header;
+}
+
+async function writeAll(file: FileHandle, bytes: Uint8Array, position: number): Promise<void> {
+    let written = 0;
+
+    while (written < bytes.byteLength) {
+        const result = await file.write(bytes, written, bytes.byteLength - written, position + written);
+        if (result.bytesWritten === 0) throw new Error('The recording file write made no progress.');
+        written += result.bytesWritten;
+    }
+}
+
+export async function recordParticipant(
+    connection: VoiceConnection,
+    userId: string,
+    outputPath = './recording.wav',
+    durationMs = 30_000,
+): Promise<void> {
+    const stream = connection.receive(userId, { maxBufferedPackets: 64 });
+
+    try {
+        const decoder = new OpusEncoder(sampleRate, channels);
+        const file = await open(outputPath, 'w');
+        let pcmByteLength = 0;
+        let filePosition = 44;
+        let timeout: ReturnType<typeof setTimeout> | undefined;
+
+        try {
+            await writeAll(file, Buffer.alloc(44), 0);
+            timeout = setTimeout(() => stream.close(), durationMs);
+
+            for await (const packet of stream) {
+                const pcm = decoder.decode(Buffer.from(packet.opus));
+                await writeAll(file, pcm, filePosition);
+                filePosition += pcm.byteLength;
+                pcmByteLength += pcm.byteLength;
+            }
+        } finally {
+            if (timeout) clearTimeout(timeout);
+
+            try {
+                await writeAll(file, createWavHeader(pcmByteLength), 0);
+            } finally {
+                await file.close();
+            }
+        }
+    } finally {
+        stream.close();
+    }
+}
+```
+
+Call it with the ready connection and the participant's Discord user ID:
+
+```ts
+await recordParticipant(connection, userId, './recording.wav', 30_000);
+```
+
+This is a minimal live recorder. The timeout controls how long it listens, not the exact output duration: participant silence and missing packets do not insert silence into the WAV. If packets are lost or dropped because the consumer falls behind, it writes the remaining decoded frames consecutively. A recorder that must preserve exact timing should use `sequence` and `timestamp` to implement its own loss and jitter policy.
+
+The subscription survives transport recovery and closes when the connection is destroyed. The package does not decode Opus to PCM or choose a recording, jitter-buffer, transcription, volume, or mixing policy.
+
+## Move or disconnect
+
+Moving to another channel must be explicit. Call `connect()` with the same guild and `move: true`:
+
+```ts
+await client.voice.connect({
+    guildId,
+    channelId: anotherChannelId,
+    move: true,
+});
+```
+
+Leave the channel through the manager:
+
+```ts
+await client.voice.disconnect(guildId);
+```
+
+The stable `VoiceConnection` exposes its current lifecycle through `connection.state.status`, which can be `connecting`, `ready`, `moving`, `disconnecting`, `recovering`, or `destroyed`.
+
+## DAVE verification
+
+DAVE protection is negotiated automatically. Once an encrypted MLS group is established, the connection exposes Discord's privacy code and can derive a pairwise verification code for another active participant:
+
+```ts
+const privacyCode = connection.voicePrivacyCode;
+const verificationCode = await connection.getVerificationCode(userId);
+```
+
+These values are for out-of-band comparison. The package exposes the canonical digits but does not decide whether an application should trust a participant.
+
+## Current limits
+
+The package exposes encoded Opus packets in both directions. Video, Go Live, soundshare, jitter buffering, recording containers, volume control, mixing, PCM conversion, and Opus encoding remain outside the core package. [`@slipher/player`](/docs/plugins/official/player) adds playback queues and optional FFmpeg transcoding without moving those policies into the voice transport.
+
+On a Stage channel, a suppressed bot cannot transmit audio. Use Seyfert's existing voice-state operations to request speaker status or remove suppression before calling `play()`.

--- a/content/docs/plugins/official/voice.mdx
+++ b/content/docs/plugins/official/voice.mdx
@@ -60,6 +60,8 @@ const connection = await client.voice.connect({
 
 `client.voice.connections` is a live read-only map keyed by guild ID. Calling `connect()` again for the same guild returns the existing connection when the target is unchanged.
 
+`connection.channelId` is the last channel Discord confirmed for that connection, or `null` before the first confirmation. During a move it remains the previous channel until Discord confirms the destination, so command handlers can compare it with the invoking member's voice channel without treating an in-flight target as already joined.
+
 ## Play an Opus file
 
 `play()` accepts complete Opus packets rather than compressed file bytes. Use the built-in demuxer to read packet boundaries from an Ogg Opus or WebM Opus stream:
@@ -108,6 +110,8 @@ await playback.stop();
 ```
 
 `playback.done` resolves after the source finishes or `stop()` completes Discord's clean silence termination. It rejects when the source or voice transport fails.
+
+`playback.playedDurationMs` reports the duration of source audio successfully sent to the voice transport. It is calculated from Opus packet sample counts, remains stable during underflow, and excludes Discord's closing silence frames.
 
 ## Receive participant audio
 


### PR DESCRIPTION
## Summary

Adds official guides for `@slipher/voice` and `@slipher/player`. The Voice guide covers plugin setup, connection lifecycle, encoded Opus playback and receive streams, participant recording, movement, and DAVE verification. The Player guide covers media sources, FFmpeg and direct Opus playback, per-guild queues, controls, history, and custom providers.

Both packages are linked from the official plugin index and sidebar, and the Voice guide points users to Player when they need source resolution, transcoding, or queue policy.